### PR TITLE
Added sane defaults to Config 

### DIFF
--- a/sunsynk-scraper/configuration.py
+++ b/sunsynk-scraper/configuration.py
@@ -10,7 +10,7 @@ def set_values_from_options(options):
     global BATTERY_DISCHARGE_RATE
     global INSECURE_MQTT
 
-    UPDATE_INTERVAL = options['update_interval']
-    DEBUG_LOGGING = options['debug_logging']
-    BATTERY_DISCHARGE_RATE = options['battery_discharge_rate']
-    INSECURE_MQTT = options['insecure_mqtt']
+    UPDATE_INTERVAL = options['update_interval'] if 'update_interval' in options else 60 
+    DEBUG_LOGGING = options['debug_logging'] if 'debug_logging' in options else False
+    BATTERY_DISCHARGE_RATE = options['battery_discharge_rate'] if 'battery_discharge_rate' in options else 2.5
+    INSECURE_MQTT = options['insecure_mqtt'] if 'insecure_mqtt' in options else False

--- a/sunsynk-scraper/credentials.py
+++ b/sunsynk-scraper/credentials.py
@@ -19,9 +19,9 @@ def set_values_from_options(options):
     global my_plant_id
     global bearer_token
 
-    mqtt_username = options['mqtt_username']
-    mqtt_password = options['mqtt_password']
-    mqtt_broker = options['mqtt_host']
-    mqtt_port = options['mqtt_port']
-    sunsynk_email = options['sunsynk_email']
-    sunsynk_password = options['sunsynk_password']
+    mqtt_username = options['mqtt_username'] if 'mqtt_username' in options else ''
+    mqtt_password = options['mqtt_password'] if 'mqtt_password' in options else ''
+    mqtt_broker = options['mqtt_host'] if 'mqtt_host' in options else '127.0.0.1'
+    mqtt_port = options['mqtt_port'] if 'mqtt_port' in options else 1883
+    sunsynk_email = options['sunsynk_email'] if 'sunsynk_email' in options else ''
+    sunsynk_password = options['sunsynk_password'] if 'sunsynk_password' in options else ''


### PR DESCRIPTION
Prevent crashing in addon when not all config options are defined (biggest issue in HASS.IO where insecure_mqtt flag can not be set, leaving 0.2.10 unusable)